### PR TITLE
First Implementation Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,103 +16,115 @@ For more details see the specific version's [README](https://github.com/deptofde
 
 -->
 
-## 1.4.0 - 5/1/2020
+## 0.2.0 - 6/1/2020
 
-### Added
+### Fixed
 
-Symptoms:
+- `calculateScores` now includes `ages`
+- `calculateLevel` now uses a level's value as an includive lower bound. Ex. `['low', 10]` means that a `score = 10` is labeled as `low` where previously it would have been labeled as `veryLow`.
+- `calculateScore` api has been updated in all calculator versions prior to calcualtor version `v1.4.0`
 
-- dizziness - likelihood: 5
+## 0.1.0 Initial Package Release - 5/28/2020
 
-Conditions:
+Below are notes about the different model versions. Moving forward these changes will be noted as the package is update. This is left here as a quick overview of the differences in each calculator version prior to open beta release.
 
-- chestPain - likelihood: 40
-
-### Changed
-
-Symptoms:
-
-- cough - likelihood: 10 (decreased by 10)
-- bodyAches - likelihood: 10 (decreased by 10)
-- headache - likelihood: 10 (decreased by 10)
-- throat - likelihood: 10 (decreased by 10)
-- lossOfSmell - likelihood: 10 (increased by 5)
-- chills - likelihood: 10 (increased by 5)
-- diarrhea - likelihood: 5 (decreased by 15)
-- fatigue - likelihood: 5 (decreased by 10)
-- eyes - likelihood: 5 (decreased by 5)
-
-Conditions:
-
-- hardBreathing - likelihood: 40 (increased by 20)
-- blueLips - likelihood: 40 (increased by 20)
-- arouse - likelihood: 40 (increased by 20)
-
-### Removed
-
-Symptoms:
-
-- chestPain
-- vomiting
-
-Conditions:
-
-- throwingUp
-- confusion
-- dizziness
-- worseningSymptoms
-
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.4.0/README.md)
-
-Following this version, the guiding rules described in [CONTRIBUTING.md](https://github.com/deptofdefense/mystatus-calculator/blob/master/CONTRIBUTING.md) will be used when determining future version numbers.
-
-## 1.3.0 - 4/28/2020
-
-### Added
-
-Symptoms:
-
-- chills - likelihood: 5
-
-Conditions:
-
-- blueLips - likelihood: 20
-- arouse - likelihood: 20
-
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.3.0/README.md)
-
-## 1.2.0 - 4/8/2020
-
-### Changed
-
-Symptoms:
-
-Increased likelihood points for a few:
-
-- bodyAches - likelihood: 20 (increased by 5)
-- headache - likelihood: 20 (increased by 10)
-- throat - likelihood: 20 (increased by 10)
-
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.2.0/README.md)
-
-## 1.1.0 - 4/7/2020
-
-### Changed
-
-Likelihood Scale:
-
-The scoring system was made more sensitive.
-
-- veryLow: 0-9 (same)
-- low: 10-19 (upper bound decreased by 10)
-- medium: 20-39 (range decreased by 10)
-- high: 40-69 (range decreased by 10)
-- veryHigh: 70+ (range decreased by 10)
-
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.1.0/README.md)
-
-## 1.0.0 - 4/3/2020
-
-This initial version was based on conversations with Department of Defense medical professionals. The scores were based on the best available information at the time.
-
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.0.0/README.md)
+> ## 1.4.0 - 5/1/2020
+>
+> ### Added
+>
+> Symptoms:
+>
+> - dizziness - likelihood: 5
+>
+> Conditions:
+>
+> - chestPain - likelihood: 40
+>
+> ### Changed
+>
+> Symptoms:
+>
+> - cough - likelihood: 10 (decreased by 10)
+> - bodyAches - likelihood: 10 (decreased by 10)
+> - headache - likelihood: 10 (decreased by 10)
+> - throat - likelihood: 10 (decreased by 10)
+> - lossOfSmell - likelihood: 10 (increased by 5)
+> - chills - likelihood: 10 (increased by 5)
+> - diarrhea - likelihood: 5 (decreased by 15)
+> - fatigue - likelihood: 5 (decreased by 10)
+> - eyes - likelihood: 5 (decreased by 5)
+>
+> Conditions:
+>
+> - hardBreathing - likelihood: 40 (increased by 20)
+> - blueLips - likelihood: 40 (increased by 20)
+> - arouse - likelihood: 40 (increased by 20)
+>
+> ### Removed
+>
+> Symptoms:
+>
+> - chestPain
+> - vomiting
+>
+> Conditions:
+>
+> - throwingUp
+> - confusion
+> - dizziness
+> - worseningSymptoms
+>
+> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.4.0/README.md)
+>
+> Following this version, the guiding rules described in [CONTRIBUTING.md](https://github.com/deptofdefense/mystatus-calculator/blob/master/CONTRIBUTING.md) will be used when determining future version numbers.
+>
+> ## 1.3.0 - 4/28/2020
+>
+> ### Added
+>
+> Symptoms:
+>
+> - chills - likelihood: 5
+>
+> Conditions:
+>
+> - blueLips - likelihood: 20
+> - arouse - likelihood: 20
+>
+> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.3.0/README.md)
+>
+> ## 1.2.0 - 4/8/2020
+>
+> ### Changed
+>
+> Symptoms:
+>
+> Increased likelihood points for a few:
+>
+> - bodyAches - likelihood: 20 (increased by 5)
+> - headache - likelihood: 20 (increased by 10)
+> - throat - likelihood: 20 (increased by 10)
+>
+> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.2.0/README.md)
+>
+> ## 1.1.0 - 4/7/2020
+>
+> ### Changed
+>
+> Likelihood Scale:
+>
+> The scoring system was made more sensitive.
+>
+> - veryLow: 0-9 (same)
+> - low: 10-19 (upper bound decreased by 10)
+> - medium: 20-39 (range decreased by 10)
+> - high: 40-69 (range decreased by 10)
+> - veryHigh: 70+ (range decreased by 10)
+>
+> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.1.0/README.md)
+>
+> ## 1.0.0 - 4/3/2020
+>
+> This initial version was based on conversations with Department of Defense medical professionals. The scores were based on the best available information at the time.
+>
+> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.0.0/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please use the following format for version changes
 
 ### Fixed
 
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/{{VERSION}}/README.md)
+For more details see the specific version's [README](https://github.com/deptofdefense/covid19-calculator/blob/master/src/{{VERSION}}/README.md)
 
 -->
 
@@ -74,9 +74,9 @@ Conditions:
 - dizziness
 - worseningSymptoms
 
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.4.0/README.md)
+For more details see the specific version's [README](https://github.com/deptofdefense/covid19-calculator/blob/master/src/v1.4.0/README.md)
 
-Following this version, the guiding rules described in [CONTRIBUTING.md](https://github.com/deptofdefense/mystatus-calculator/blob/master/CONTRIBUTING.md) will be used when determining future version numbers.
+Following this version, the guiding rules described in [CONTRIBUTING.md](https://github.com/deptofdefense/covid19-calculator/blob/master/CONTRIBUTING.md) will be used when determining future version numbers.
 
 ### 1.3.0 - 4/28/2020
 
@@ -91,7 +91,7 @@ Conditions:
 - blueLips - likelihood: 20
 - arouse - likelihood: 20
 
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.3.0/README.md)
+For more details see the specific version's [README](https://github.com/deptofdefense/covid19-calculator/blob/master/src/v1.3.0/README.md)
 
 ### 1.2.0 - 4/8/2020
 
@@ -105,7 +105,7 @@ Increased likelihood points for a few:
 - headache - likelihood: 20 (increased by 10)
 - throat - likelihood: 20 (increased by 10)
 
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.2.0/README.md)
+For more details see the specific version's [README](https://github.com/deptofdefense/covid19-calculator/blob/master/src/v1.2.0/README.md)
 
 ### 1.1.0 - 4/7/2020
 
@@ -121,10 +121,10 @@ The scoring system was made more sensitive.
 - high: 40-69 (range decreased by 10)
 - veryHigh: 70+ (range decreased by 10)
 
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.1.0/README.md)
+For more details see the specific version's [README](https://github.com/deptofdefense/covid19-calculator/blob/master/src/v1.1.0/README.md)
 
 ### 1.0.0 - 4/3/2020
 
 This initial version was based on conversations with Department of Defense medical professionals. The scores were based on the best available information at the time.
 
-For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.0.0/README.md)
+For more details see the specific version's [README](https://github.com/deptofdefense/covid19-calculator/blob/master/src/v1.0.0/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,103 +28,103 @@ For more details see the specific version's [README](https://github.com/deptofde
 
 Below are notes about the different model versions. Moving forward these changes will be noted as the package is update. This is left here as a quick overview of the differences in each calculator version prior to open beta release.
 
-> ## 1.4.0 - 5/1/2020
->
-> ### Added
->
-> Symptoms:
->
-> - dizziness - likelihood: 5
->
-> Conditions:
->
-> - chestPain - likelihood: 40
->
-> ### Changed
->
-> Symptoms:
->
-> - cough - likelihood: 10 (decreased by 10)
-> - bodyAches - likelihood: 10 (decreased by 10)
-> - headache - likelihood: 10 (decreased by 10)
-> - throat - likelihood: 10 (decreased by 10)
-> - lossOfSmell - likelihood: 10 (increased by 5)
-> - chills - likelihood: 10 (increased by 5)
-> - diarrhea - likelihood: 5 (decreased by 15)
-> - fatigue - likelihood: 5 (decreased by 10)
-> - eyes - likelihood: 5 (decreased by 5)
->
-> Conditions:
->
-> - hardBreathing - likelihood: 40 (increased by 20)
-> - blueLips - likelihood: 40 (increased by 20)
-> - arouse - likelihood: 40 (increased by 20)
->
-> ### Removed
->
-> Symptoms:
->
-> - chestPain
-> - vomiting
->
-> Conditions:
->
-> - throwingUp
-> - confusion
-> - dizziness
-> - worseningSymptoms
->
-> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.4.0/README.md)
->
-> Following this version, the guiding rules described in [CONTRIBUTING.md](https://github.com/deptofdefense/mystatus-calculator/blob/master/CONTRIBUTING.md) will be used when determining future version numbers.
->
-> ## 1.3.0 - 4/28/2020
->
-> ### Added
->
-> Symptoms:
->
-> - chills - likelihood: 5
->
-> Conditions:
->
-> - blueLips - likelihood: 20
-> - arouse - likelihood: 20
->
-> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.3.0/README.md)
->
-> ## 1.2.0 - 4/8/2020
->
-> ### Changed
->
-> Symptoms:
->
-> Increased likelihood points for a few:
->
-> - bodyAches - likelihood: 20 (increased by 5)
-> - headache - likelihood: 20 (increased by 10)
-> - throat - likelihood: 20 (increased by 10)
->
-> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.2.0/README.md)
->
-> ## 1.1.0 - 4/7/2020
->
-> ### Changed
->
-> Likelihood Scale:
->
-> The scoring system was made more sensitive.
->
-> - veryLow: 0-9 (same)
-> - low: 10-19 (upper bound decreased by 10)
-> - medium: 20-39 (range decreased by 10)
-> - high: 40-69 (range decreased by 10)
-> - veryHigh: 70+ (range decreased by 10)
->
-> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.1.0/README.md)
->
-> ## 1.0.0 - 4/3/2020
->
-> This initial version was based on conversations with Department of Defense medical professionals. The scores were based on the best available information at the time.
->
-> For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.0.0/README.md)
+### 1.4.0 - 5/1/2020
+
+#### Added
+
+Symptoms:
+
+- dizziness - likelihood: 5
+
+Conditions:
+
+- chestPain - likelihood: 40
+
+#### Changed
+
+Symptoms:
+
+- cough - likelihood: 10 (decreased by 10)
+- bodyAches - likelihood: 10 (decreased by 10)
+- headache - likelihood: 10 (decreased by 10)
+- throat - likelihood: 10 (decreased by 10)
+- lossOfSmell - likelihood: 10 (increased by 5)
+- chills - likelihood: 10 (increased by 5)
+- diarrhea - likelihood: 5 (decreased by 15)
+- fatigue - likelihood: 5 (decreased by 10)
+- eyes - likelihood: 5 (decreased by 5)
+
+Conditions:
+
+- hardBreathing - likelihood: 40 (increased by 20)
+- blueLips - likelihood: 40 (increased by 20)
+- arouse - likelihood: 40 (increased by 20)
+
+#### Removed
+
+Symptoms:
+
+- chestPain
+- vomiting
+
+Conditions:
+
+- throwingUp
+- confusion
+- dizziness
+- worseningSymptoms
+
+For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.4.0/README.md)
+
+Following this version, the guiding rules described in [CONTRIBUTING.md](https://github.com/deptofdefense/mystatus-calculator/blob/master/CONTRIBUTING.md) will be used when determining future version numbers.
+
+### 1.3.0 - 4/28/2020
+
+#### Added
+
+Symptoms:
+
+- chills - likelihood: 5
+
+Conditions:
+
+- blueLips - likelihood: 20
+- arouse - likelihood: 20
+
+For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.3.0/README.md)
+
+### 1.2.0 - 4/8/2020
+
+#### Changed
+
+Symptoms:
+
+Increased likelihood points for a few:
+
+- bodyAches - likelihood: 20 (increased by 5)
+- headache - likelihood: 20 (increased by 10)
+- throat - likelihood: 20 (increased by 10)
+
+For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.2.0/README.md)
+
+### 1.1.0 - 4/7/2020
+
+#### Changed
+
+Likelihood Scale:
+
+The scoring system was made more sensitive.
+
+- veryLow: 0-9 (same)
+- low: 10-19 (upper bound decreased by 10)
+- medium: 20-39 (range decreased by 10)
+- high: 40-69 (range decreased by 10)
+- veryHigh: 70+ (range decreased by 10)
+
+For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.1.0/README.md)
+
+### 1.0.0 - 4/3/2020
+
+This initial version was based on conversations with Department of Defense medical professionals. The scores were based on the best available information at the time.
+
+For more details see the specific version's [README](https://github.com/deptofdefense/mystatus-calculator/blob/master/src/v1.0.0/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ For more details see the specific version's [README](https://github.com/deptofde
 
 - `calculateScores` now includes `ages`
 - `calculateLevel` now uses a level's value as an includive lower bound. Ex. `['low', 10]` means that a `score = 10` is labeled as `low` where previously it would have been labeled as `veryLow`.
-- `calculateScore` api has been updated in all calculator versions prior to calcualtor version `v1.4.0`
+- `calculateScore` api has been updated in all calculator versions prior to calculator version `v1.4.0`
 
 ## 0.1.0 Initial Package Release - 5/28/2020
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ There are two types of versioning for this project: package versioning and calcu
 
 ### Package Versioning
 
-Package versioning is the version number included in the [package.json](package.json) and used to ensure the intended version of this repo is imported into other programs. This version is encoded as `major.minor.patch` semantic version. The minor version number will be incremented with every API change until a stable version is released as `1.0.0`. To only receive patch updates, use `~0.1.0`.
+Package versioning is the version number included in the [package.json](package.json) and used to ensure the intended version of this repo is imported into other programs. This version is encoded as `major.minor.patch` semantic version. The minor version number will be incremented with every API change until a stable version is released as `1.0.0`. To only receive patch updates, use `~0.2.0`.
 
 ### Calculator Versioning
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,16 @@ This calculator is currently maintained by [Defense Digital Service](https://dds
 
 ### Installation
 
+NPM:
+
 ```
-npm install @deptofdefense/covid19-calculator or yarn add @deptofdefense/covid19-calculator
+npm install @deptofdefense/covid19-calculator
+```
+
+Yarn:
+
+```
+yarn add @deptofdefense/covid19-calculator
 ```
 
 ### Latest Calculator

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # COVID-19 Calculator
 
+[![npm version](https://badge.fury.io/js/%40deptofdefense%2Fcovid19-calculator.svg)](https://badge.fury.io/js/%40deptofdefense%2Fcovid19-calculator)
+
 ## Description
 
 COVID-19 Calculator provides a set of scoring algorithms for evaluating COVID-19 symptoms implemented in [TypeScript](https://www.typescriptlang.org/). The algorithms and associated inputs in this model are based on United States Department of Defense medical opinion and are actively used in [MySymptoms.mil](https://mysymptoms.mil/).

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "module": "dist/mystatus-model.esm.js",
+  "module": "dist/covid19-calculator.esm.js",
   "devDependencies": {
     "husky": "^4.2.5",
     "tsdx": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "DDS",
     "Defense Digital Service"
   ],
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/v1.0.0/scale.ts
+++ b/src/v1.0.0/scale.ts
@@ -62,7 +62,7 @@ export const scale: ScaleLevels = {
 };
 
 type DataType = typeof scoreData;
-export type MyStatusData = Partial<
+export type DataToScore = Partial<
   {
     [K in keyof DataType]: string[];
   }
@@ -86,7 +86,7 @@ export const calculateScore = (
   return mergeScores(...collection.filter(item => values.includes(item.key)));
 };
 
-export const calculateScores = (dataToScore: MyStatusData) => {
+export const calculateScores = (dataToScore: DataToScore) => {
   const {
     ages = [],
     exposures = [],
@@ -132,7 +132,7 @@ export const calculateLevels = (scores: ScoredData): LevelData =>
     };
   }, {} as LevelData);
 
-export const calculate = (dataToScore: MyStatusData) => {
+export const calculate = (dataToScore: DataToScore) => {
   const scores = calculateScores(dataToScore);
 
   const levels = calculateLevels(scores);

--- a/src/v1.0.0/scale.ts
+++ b/src/v1.0.0/scale.ts
@@ -79,15 +79,16 @@ const mergeScores = (...args: Partial<ScoredData>[]): ScoredData =>
   );
 
 export const calculateScore = (
-  values: string[],
-  collection: ScorableCollection<string>
-): ScoredData =>
-  mergeScores(
-    ...collection.filter(collection => values.includes(collection.key))
-  );
+  ScoreCategory: keyof typeof scoreData,
+  values: string[]
+): ScoredData => {
+  const collection = scoreData[ScoreCategory] as ScorableCollection<string>;
+  return mergeScores(...collection.filter(item => values.includes(item.key)));
+};
 
 export const calculateScores = (dataToScore: MyStatusData) => {
   const {
+    ages = [],
     exposures = [],
     preExistingConditions = [],
     conditions = [],
@@ -95,10 +96,11 @@ export const calculateScores = (dataToScore: MyStatusData) => {
   } = dataToScore;
 
   const scores = mergeScores(
-    calculateScore(exposures, scoreData.exposures),
-    calculateScore(preExistingConditions, scoreData.preExistingConditions),
-    calculateScore(conditions, scoreData.conditions),
-    calculateScore(symptoms, scoreData.symptoms)
+    calculateScore('ages', ages),
+    calculateScore('exposures', exposures),
+    calculateScore('preExistingConditions', preExistingConditions),
+    calculateScore('conditions', conditions),
+    calculateScore('symptoms', symptoms)
   );
 
   return scores;
@@ -114,7 +116,7 @@ export const calculateLevel = (category: ScoreCategory, score: number) => {
   let result = lowest[0];
 
   for (let [level, threshold] of rest) {
-    if (score > threshold) {
+    if (score >= threshold) {
       result = level;
     }
   }

--- a/src/v1.1.0/scale.ts
+++ b/src/v1.1.0/scale.ts
@@ -62,7 +62,7 @@ export const scale: ScaleLevels = {
 };
 
 type DataType = typeof scoreData;
-export type MyStatusData = Partial<
+export type DataToScore = Partial<
   {
     [K in keyof DataType]: string[];
   }
@@ -86,7 +86,7 @@ export const calculateScore = (
   return mergeScores(...collection.filter(item => values.includes(item.key)));
 };
 
-export const calculateScores = (dataToScore: MyStatusData) => {
+export const calculateScores = (dataToScore: DataToScore) => {
   const {
     ages = [],
     exposures = [],
@@ -132,7 +132,7 @@ export const calculateLevels = (scores: ScoredData): LevelData =>
     };
   }, {} as LevelData);
 
-export const calculate = (dataToScore: MyStatusData) => {
+export const calculate = (dataToScore: DataToScore) => {
   const scores = calculateScores(dataToScore);
 
   const levels = calculateLevels(scores);

--- a/src/v1.1.0/scale.ts
+++ b/src/v1.1.0/scale.ts
@@ -79,15 +79,16 @@ const mergeScores = (...args: Partial<ScoredData>[]): ScoredData =>
   );
 
 export const calculateScore = (
-  values: string[],
-  collection: ScorableCollection<string>
-): ScoredData =>
-  mergeScores(
-    ...collection.filter(collection => values.includes(collection.key))
-  );
+  ScoreCategory: keyof typeof scoreData,
+  values: string[]
+): ScoredData => {
+  const collection = scoreData[ScoreCategory] as ScorableCollection<string>;
+  return mergeScores(...collection.filter(item => values.includes(item.key)));
+};
 
 export const calculateScores = (dataToScore: MyStatusData) => {
   const {
+    ages = [],
     exposures = [],
     preExistingConditions = [],
     conditions = [],
@@ -95,10 +96,11 @@ export const calculateScores = (dataToScore: MyStatusData) => {
   } = dataToScore;
 
   const scores = mergeScores(
-    calculateScore(exposures, scoreData.exposures),
-    calculateScore(preExistingConditions, scoreData.preExistingConditions),
-    calculateScore(conditions, scoreData.conditions),
-    calculateScore(symptoms, scoreData.symptoms)
+    calculateScore('ages', ages),
+    calculateScore('exposures', exposures),
+    calculateScore('preExistingConditions', preExistingConditions),
+    calculateScore('conditions', conditions),
+    calculateScore('symptoms', symptoms)
   );
 
   return scores;
@@ -114,7 +116,7 @@ export const calculateLevel = (category: ScoreCategory, score: number) => {
   let result = lowest[0];
 
   for (let [level, threshold] of rest) {
-    if (score > threshold) {
+    if (score >= threshold) {
       result = level;
     }
   }

--- a/src/v1.2.0/scale.ts
+++ b/src/v1.2.0/scale.ts
@@ -62,7 +62,7 @@ export const scale: ScaleLevels = {
 };
 
 type DataType = typeof scoreData;
-export type MyStatusData = Partial<
+export type DataToScore = Partial<
   {
     [K in keyof DataType]: string[];
   }
@@ -86,7 +86,7 @@ export const calculateScore = (
   return mergeScores(...collection.filter(item => values.includes(item.key)));
 };
 
-export const calculateScores = (dataToScore: MyStatusData) => {
+export const calculateScores = (dataToScore: DataToScore) => {
   const {
     ages = [],
     exposures = [],
@@ -132,7 +132,7 @@ export const calculateLevels = (scores: ScoredData): LevelData =>
     };
   }, {} as LevelData);
 
-export const calculate = (dataToScore: MyStatusData) => {
+export const calculate = (dataToScore: DataToScore) => {
   const scores = calculateScores(dataToScore);
 
   const levels = calculateLevels(scores);

--- a/src/v1.2.0/scale.ts
+++ b/src/v1.2.0/scale.ts
@@ -79,15 +79,16 @@ const mergeScores = (...args: Partial<ScoredData>[]): ScoredData =>
   );
 
 export const calculateScore = (
-  values: string[],
-  collection: ScorableCollection<string>
-): ScoredData =>
-  mergeScores(
-    ...collection.filter(collection => values.includes(collection.key))
-  );
+  ScoreCategory: keyof typeof scoreData,
+  values: string[]
+): ScoredData => {
+  const collection = scoreData[ScoreCategory] as ScorableCollection<string>;
+  return mergeScores(...collection.filter(item => values.includes(item.key)));
+};
 
 export const calculateScores = (dataToScore: MyStatusData) => {
   const {
+    ages = [],
     exposures = [],
     preExistingConditions = [],
     conditions = [],
@@ -95,10 +96,11 @@ export const calculateScores = (dataToScore: MyStatusData) => {
   } = dataToScore;
 
   const scores = mergeScores(
-    calculateScore(exposures, scoreData.exposures),
-    calculateScore(preExistingConditions, scoreData.preExistingConditions),
-    calculateScore(conditions, scoreData.conditions),
-    calculateScore(symptoms, scoreData.symptoms)
+    calculateScore('ages', ages),
+    calculateScore('exposures', exposures),
+    calculateScore('preExistingConditions', preExistingConditions),
+    calculateScore('conditions', conditions),
+    calculateScore('symptoms', symptoms)
   );
 
   return scores;
@@ -114,7 +116,7 @@ export const calculateLevel = (category: ScoreCategory, score: number) => {
   let result = lowest[0];
 
   for (let [level, threshold] of rest) {
-    if (score > threshold) {
+    if (score >= threshold) {
       result = level;
     }
   }

--- a/src/v1.3.0/scale.ts
+++ b/src/v1.3.0/scale.ts
@@ -62,7 +62,7 @@ export const scale: ScaleLevels = {
 };
 
 type DataType = typeof scoreData;
-export type MyStatusData = Partial<
+export type DataToScore = Partial<
   {
     [K in keyof DataType]: string[];
   }
@@ -86,7 +86,7 @@ export const calculateScore = (
   return mergeScores(...collection.filter(item => values.includes(item.key)));
 };
 
-export const calculateScores = (dataToScore: MyStatusData) => {
+export const calculateScores = (dataToScore: DataToScore) => {
   const {
     ages = [],
     exposures = [],
@@ -132,7 +132,7 @@ export const calculateLevels = (scores: ScoredData): LevelData =>
     };
   }, {} as LevelData);
 
-export const calculate = (dataToScore: MyStatusData) => {
+export const calculate = (dataToScore: DataToScore) => {
   const scores = calculateScores(dataToScore);
 
   const levels = calculateLevels(scores);

--- a/src/v1.3.0/scale.ts
+++ b/src/v1.3.0/scale.ts
@@ -79,15 +79,16 @@ const mergeScores = (...args: Partial<ScoredData>[]): ScoredData =>
   );
 
 export const calculateScore = (
-  values: string[],
-  collection: ScorableCollection<string>
-): ScoredData =>
-  mergeScores(
-    ...collection.filter(collection => values.includes(collection.key))
-  );
+  ScoreCategory: keyof typeof scoreData,
+  values: string[]
+): ScoredData => {
+  const collection = scoreData[ScoreCategory] as ScorableCollection<string>;
+  return mergeScores(...collection.filter(item => values.includes(item.key)));
+};
 
 export const calculateScores = (dataToScore: MyStatusData) => {
   const {
+    ages = [],
     exposures = [],
     preExistingConditions = [],
     conditions = [],
@@ -95,10 +96,11 @@ export const calculateScores = (dataToScore: MyStatusData) => {
   } = dataToScore;
 
   const scores = mergeScores(
-    calculateScore(exposures, scoreData.exposures),
-    calculateScore(preExistingConditions, scoreData.preExistingConditions),
-    calculateScore(conditions, scoreData.conditions),
-    calculateScore(symptoms, scoreData.symptoms)
+    calculateScore('ages', ages),
+    calculateScore('exposures', exposures),
+    calculateScore('preExistingConditions', preExistingConditions),
+    calculateScore('conditions', conditions),
+    calculateScore('symptoms', symptoms)
   );
 
   return scores;
@@ -114,7 +116,7 @@ export const calculateLevel = (category: ScoreCategory, score: number) => {
   let result = lowest[0];
 
   for (let [level, threshold] of rest) {
-    if (score > threshold) {
+    if (score >= threshold) {
       result = level;
     }
   }

--- a/src/v1.4.0/scale.ts
+++ b/src/v1.4.0/scale.ts
@@ -62,7 +62,7 @@ export const scale: ScaleLevels = {
 };
 
 type DataType = typeof scoreData;
-export type MyStatusData = Partial<
+export type DataToScore = Partial<
   {
     [K in keyof DataType]: string[];
   }
@@ -86,7 +86,7 @@ export const calculateScore = (
   return mergeScores(...collection.filter(item => values.includes(item.key)));
 };
 
-export const calculateScores = (dataToScore: MyStatusData) => {
+export const calculateScores = (dataToScore: DataToScore) => {
   const {
     ages = [],
     exposures = [],
@@ -132,7 +132,7 @@ export const calculateLevels = (scores: ScoredData): LevelData =>
     };
   }, {} as LevelData);
 
-export const calculate = (dataToScore: MyStatusData) => {
+export const calculate = (dataToScore: DataToScore) => {
   const scores = calculateScores(dataToScore);
   const levels = calculateLevels(scores);
 

--- a/src/v1.4.0/scale.ts
+++ b/src/v1.4.0/scale.ts
@@ -88,6 +88,7 @@ export const calculateScore = (
 
 export const calculateScores = (dataToScore: MyStatusData) => {
   const {
+    ages = [],
     exposures = [],
     preExistingConditions = [],
     conditions = [],
@@ -95,6 +96,7 @@ export const calculateScores = (dataToScore: MyStatusData) => {
   } = dataToScore;
 
   const scores = mergeScores(
+    calculateScore('ages', ages),
     calculateScore('exposures', exposures),
     calculateScore('preExistingConditions', preExistingConditions),
     calculateScore('conditions', conditions),
@@ -114,7 +116,7 @@ export const calculateLevel = (category: ScoreCategory, score: number) => {
   let result = lowest[0];
 
   for (let [level, threshold] of rest) {
-    if (score > threshold) {
+    if (score >= threshold) {
       result = level;
     }
   }

--- a/test/scoring.spec.ts
+++ b/test/scoring.spec.ts
@@ -1,6 +1,6 @@
 import {
   calculate,
-  MyStatusData,
+  DataToScore,
   emptyScore,
   ScoredData,
   LevelData,
@@ -33,7 +33,7 @@ const emptyLevel: LevelData = {
 };
 
 export const makeLabel = (
-  data: MyStatusData,
+  data: DataToScore,
   expectScore: ScoredData,
   expectLevel: LevelData
 ) => {
@@ -65,7 +65,7 @@ export const makeLabel = (
 };
 
 const assess = (
-  data: MyStatusData,
+  data: DataToScore,
   expectScore?: ScoredData,
   expectLevel?: LevelData
 ) => {

--- a/test/scoring.spec.ts
+++ b/test/scoring.spec.ts
@@ -38,6 +38,7 @@ export const makeLabel = (
   expectLevel: LevelData
 ) => {
   const {
+    ages = [],
     symptoms = [],
     preExistingConditions = [],
     conditions = [],
@@ -51,7 +52,13 @@ export const makeLabel = (
     `(${normalizeLevel(expectLevel.likelihood)}|` +
     `${normalizeLevel(expectLevel.exposure)}|` +
     `${normalizeLevel(expectLevel.preExisting)}) ` +
-    [...symptoms, ...conditions, ...exposures, ...preExistingConditions]
+    [
+      ...ages,
+      ...symptoms,
+      ...conditions,
+      ...exposures,
+      ...preExistingConditions,
+    ]
       .sort()
       .join(', ')
   );
@@ -83,10 +90,18 @@ describe('Can calculate scores', () => {
 
   assess(
     {
+      ages: ['80-Infinity'],
+    },
+    { preExisting: 20 },
+    { preExisting: 'medium' }
+  );
+
+  assess(
+    {
       conditions: ['arouse'],
     },
     { likelihood: 40 },
-    { likelihood: 'medium' }
+    { likelihood: 'high' }
   );
 
   assess(
@@ -95,6 +110,9 @@ describe('Can calculate scores', () => {
     },
     {
       likelihood: 10,
+    },
+    {
+      likelihood: 'low',
     }
   );
 


### PR DESCRIPTION
This PR contains a number of fixes found while attempting to integrate with mysyptoms.mil. Below are the updates that were made:

- `calculateLevel` now checks for `scores >= threshold` instead of just `>`. This means, for example, that if a break in a scale were at 40, a score of 40 would be given the higher label where previously it was given the lower. (`likelihoodScore: 10` is now `low` not `veryLow`) Tests updated to confirm this is working as expected. This has been propagated back to all previous versions.
- `calculateScores` now includes `ages` in the calculation. This was a bug when `ages` was added late in the closed alpha period. Tests were added to confirm this is working correctly. This has been propagated back to all previous versions.
- `calculateScore` api has been updated in all versions prior to `v1.4.0` this was a bug not caught before moving the repo to open beta.

EDIT:
This PR now contains a number of other fixes for the README and CHANGELOG as well.